### PR TITLE
이미지 서비스 리팩토링

### DIFF
--- a/src/main/java/com/runningmate/runningmate/common/handler/ImageStatusTypeHandler.java
+++ b/src/main/java/com/runningmate/runningmate/common/handler/ImageStatusTypeHandler.java
@@ -1,0 +1,54 @@
+package com.runningmate.runningmate.common.handler;
+
+import com.runningmate.runningmate.image.domain.entity.ImageStatus;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class ImageStatusTypeHandler<E extends Enum<E>> implements TypeHandler<ImageStatus> {
+
+    private final Class<E> type;
+
+    public ImageStatusTypeHandler(Class<E> type) {
+        this.type = type;
+    }
+
+    @Override
+    public void setParameter(PreparedStatement preparedStatement, int i, ImageStatus imageStatus,
+        JdbcType jdbcType) throws SQLException {
+        preparedStatement.setInt(i, imageStatus.getCode());
+    }
+
+    @Override
+    public ImageStatus getResult(ResultSet resultSet, String s) throws SQLException {
+        return getImageStatus(resultSet.getInt(s));
+    }
+
+    @Override
+    public ImageStatus getResult(ResultSet resultSet, int i) throws SQLException {
+        return getImageStatus(resultSet.getInt(i));
+    }
+
+    @Override
+    public ImageStatus getResult(CallableStatement callableStatement, int i) throws SQLException {
+        return getImageStatus(callableStatement.getInt(i));
+    }
+
+    private ImageStatus getImageStatus(int code) {
+        try {
+            ImageStatus[] enumConstants = (ImageStatus[]) type.getEnumConstants();
+            for (ImageStatus imageStatus : enumConstants) {
+                if (imageStatus.getCode() == code) {
+                    return imageStatus;
+                }
+            }
+            return null;
+        } catch (Exception exception) {
+            throw new TypeException();
+        }
+    }
+}

--- a/src/main/java/com/runningmate/runningmate/configuration/DataBaseConfiguration.java
+++ b/src/main/java/com/runningmate/runningmate/configuration/DataBaseConfiguration.java
@@ -1,7 +1,9 @@
 package com.runningmate.runningmate.configuration;
 
+import com.runningmate.runningmate.image.domain.entity.ImageStatus;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,22 +18,22 @@ import javax.sql.DataSource;
 @Configuration
 public class DataBaseConfiguration {
 
-    @Bean(name="dataSource")
+    @Bean(name = "dataSource")
     @ConfigurationProperties(prefix = "spring.datasource")
-    public DataSource dataSource(){
+    public DataSource dataSource() {
         return DataSourceBuilder
-                .create()
-                .type(HikariDataSource.class)
-                .build();
+            .create()
+            .type(HikariDataSource.class)
+            .build();
     }
 
 
     @Bean(name = "sessionFactory")
-    public SqlSessionFactory sessionFactory(DataSource dataSource,
-                                            ApplicationContext applicationContext) throws Exception {
+    public SqlSessionFactory sessionFactory(DataSource dataSource, ApplicationContext applicationContext) throws Exception {
         SqlSessionFactoryBean sqlSessionFactoryBean = new SqlSessionFactoryBean();
         sqlSessionFactoryBean.setDataSource(dataSource);
         sqlSessionFactoryBean.setMapperLocations(applicationContext.getResources("classpath:mapper/**/**.xml"));
+        sqlSessionFactoryBean.setTypeHandlers(new TypeHandler[]{new ImageStatus.TypeHandler()});
         return sqlSessionFactoryBean.getObject();
     }
 
@@ -40,6 +42,4 @@ public class DataBaseConfiguration {
         sessionFactory.getConfiguration().setMapUnderscoreToCamelCase(true);
         return new SqlSessionTemplate(sessionFactory);
     }
-
-
 }

--- a/src/main/java/com/runningmate/runningmate/image/domain/entity/Image.java
+++ b/src/main/java/com/runningmate/runningmate/image/domain/entity/Image.java
@@ -1,5 +1,7 @@
 package com.runningmate.runningmate.image.domain.entity;
 
+import static com.runningmate.runningmate.image.domain.entity.ImageStatus.*;
+
 import lombok.*;
 import org.springframework.util.StringUtils;
 
@@ -11,16 +13,24 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Image {
+
     private long imageId;
+    private ImageStatus status;
     private String originalFileName;
     private String storageFileName;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 
     public static class ImageBuilder {
+
         public ImageBuilder storageFileName(String originalFileName) {
             this.storageFileName = UUID.randomUUID() + "." + StringUtils.getFilenameExtension(originalFileName);
             return this;
         }
+    }
+
+    public void delete() {
+        status = NOT_USED;
+        updateDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/runningmate/runningmate/image/domain/entity/ImageStatus.java
+++ b/src/main/java/com/runningmate/runningmate/image/domain/entity/ImageStatus.java
@@ -1,0 +1,24 @@
+package com.runningmate.runningmate.image.domain.entity;
+
+import com.runningmate.runningmate.common.handler.ImageStatusTypeHandler;
+import lombok.Getter;
+import org.apache.ibatis.type.MappedTypes;
+
+public enum ImageStatus {
+    BEING_USED(1),
+    NOT_USED(0);
+
+    @Getter
+    private final int code;
+
+    ImageStatus(int code) {
+        this.code = code;
+    }
+
+    @MappedTypes(ImageStatus.class)
+    public static class TypeHandler extends ImageStatusTypeHandler<ImageStatus> {
+        public TypeHandler() {
+            super(ImageStatus.class);
+        }
+    }
+}

--- a/src/main/java/com/runningmate/runningmate/image/domain/mapper/ImageMapper.java
+++ b/src/main/java/com/runningmate/runningmate/image/domain/mapper/ImageMapper.java
@@ -7,5 +7,5 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ImageMapper {
     public Image selectImage(long imageId);
     public void insertImage(Image image);
-    public void deleteImage(Image image);
+    public void updateImage(Image image);
 }

--- a/src/main/java/com/runningmate/runningmate/image/domain/repository/ImageRepository.java
+++ b/src/main/java/com/runningmate/runningmate/image/domain/repository/ImageRepository.java
@@ -3,7 +3,10 @@ package com.runningmate.runningmate.image.domain.repository;
 import com.runningmate.runningmate.image.domain.entity.Image;
 
 public interface ImageRepository {
+
     public Image findById(long imageId);
+
     public void save(Image image);
-    public void delete(Image image);
+
+    public void update(Image image);
 }

--- a/src/main/java/com/runningmate/runningmate/image/domain/repository/MybatisImageRepository.java
+++ b/src/main/java/com/runningmate/runningmate/image/domain/repository/MybatisImageRepository.java
@@ -22,7 +22,7 @@ public class MybatisImageRepository implements ImageRepository {
     }
 
     @Override
-    public void delete(Image image) {
-        imageMapper.deleteImage(image);
+    public void update(Image image) {
+        imageMapper.updateImage(image);
     }
 }

--- a/src/main/java/com/runningmate/runningmate/image/service/AwsS3ImageUploadService.java
+++ b/src/main/java/com/runningmate/runningmate/image/service/AwsS3ImageUploadService.java
@@ -70,6 +70,7 @@ public class AwsS3ImageUploadService implements ImageUploadService {
     }
 
     @Override
+    @Transactional
     public void delete(long imageId) {
         Image image = mybatisImageRepository.findById(imageId);
         image.delete();

--- a/src/main/java/com/runningmate/runningmate/image/service/ImageUploadService.java
+++ b/src/main/java/com/runningmate/runningmate/image/service/ImageUploadService.java
@@ -4,6 +4,8 @@ import com.runningmate.runningmate.image.domain.entity.Image;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ImageUploadService {
+
     public Image upload(MultipartFile file);
-    public void delete(Image image);
+
+    public void delete(long imageId);
 }

--- a/src/main/resources/mapper/image/ImageMapper.xml
+++ b/src/main/resources/mapper/image/ImageMapper.xml
@@ -5,6 +5,7 @@
     <select id="selectImage" resultType="com.runningmate.runningmate.image.domain.entity.Image">
         SELECT
             image_id
+            , status
             , original_file_name
             , storage_file_name
             , create_date
@@ -16,20 +17,26 @@
     <insert id="insertImage" parameterType="com.runningmate.runningmate.image.domain.entity.Image" useGeneratedKeys="true" keyProperty="imageId">
         INSERT INTO
             image (
-                original_file_name
+                status
+                , original_file_name
                 , storage_file_name
                 , create_date
+                , update_date
             )
-            VALUES
-            (
-                #{originalFileName}
+            VALUES (
+                #{status}
+                , #{originalFileName}
                 , #{storageFileName}
                 , #{createDate}
+                , #{updateDate}
             )
     </insert>
 
-    <delete id="deleteImage" parameterType="com.runningmate.runningmate.image.domain.entity.Image">
-        DELETE FROM image
-        WHERE image_id = #{imageId}
-    </delete>
+    <update id="updateImage" parameterType="com.runningmate.runningmate.image.domain.entity.Image">
+        UPDATE image
+           SET status = #{status}
+             , original_file_name = #{originalFileName}
+             , storage_file_name = #{storageFileName}
+             , update_date = #{updateDate}
+    </update>
 </mapper>


### PR DESCRIPTION
## 작업내용
- 트랜잭션 처리를 통해 AWS S3에 업로드 중 오류 발생시 데이터베이스에 데이터가 저장되지 않도록 수정
- AwsS3ImageUploadService 내부에서만 사용되는 메소드 접근제한자 private로 수정
- 이미지 삭제 시 바로 레코드가 DELETE 되지 않고 Image 테이블에 status 컬럼을 추가해 컬럼 값을 변경해주도록 수정
    - Image Entity의 status 타입은 enum으로 Database에서 status컬럼의 type은 tinyint로 설정
    - TypeHandler를 사용해 변수 타입과 테이블 컬럼 타입이 맞지않아 발생하는 문제 해결