### PR TITLE
프로젝트 등록 기능 리팩토링

### DIFF
--- a/src/main/java/com/runningmate/runningmate/project/controller/ProjectController.java
+++ b/src/main/java/com/runningmate/runningmate/project/controller/ProjectController.java
@@ -20,13 +20,9 @@ public class ProjectController {
 
     @PostMapping("/project")
     public ResponseEntity<?> addProject(@RequestPart("project") @Valid ProjectSaveRequestDto projectCreateRequestDto, @RequestPart("file") MultipartFile multipartFile, HttpSession session) {
-        String loginUserEmail = SessionUtils.getLoginSessionEmail(session);
+        long userId = SessionUtils.getLoginSessionUserId();
 
-        if (loginUserEmail.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-        } else {
-            projectService.createProject(loginUserEmail, projectCreateRequestDto, multipartFile);
-        }
+        projectService.createProject(userId, projectCreateRequestDto, multipartFile);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/runningmate/runningmate/project/service/ProjectService.java
+++ b/src/main/java/com/runningmate/runningmate/project/service/ProjectService.java
@@ -8,7 +8,6 @@ import com.runningmate.runningmate.project.domain.repository.ProjectPositionRepo
 import com.runningmate.runningmate.project.domain.repository.ProjectRepository;
 import com.runningmate.runningmate.project.domain.repository.ProjectSkillRepository;
 import com.runningmate.runningmate.project.dto.ProjectSaveRequestDto;
-import com.runningmate.runningmate.user.entity.User;
 import com.runningmate.runningmate.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,12 +32,11 @@ public class ProjectService {
     private final ImageUploadService awsS3ImageUploadService;
 
     @Transactional
-    public void createProject(String email, ProjectSaveRequestDto projectSaveRequestDto, MultipartFile multipartFile) {
-        User leader = mybatisUserRepository.findByEmail(email);
+    public void createProject(long userId, ProjectSaveRequestDto projectSaveRequestDto, MultipartFile multipartFile) {
         Image image = awsS3ImageUploadService.upload(multipartFile);
 
         Project project = Project.builder()
-            .leader(leader.getUserId())
+            .leader(userId)
             .beginDate(projectSaveRequestDto.getBeginDate())
             .endDate(projectSaveRequestDto.getEndDate())
             .title(projectSaveRequestDto.getTitle())

--- a/src/test/java/com/runningmate/runningmate/project/ProjectServiceTest.java
+++ b/src/test/java/com/runningmate/runningmate/project/ProjectServiceTest.java
@@ -1,6 +1,5 @@
 package com.runningmate.runningmate.project;
 
-import com.runningmate.runningmate.common.utils.SessionUtils;
 import com.runningmate.runningmate.image.domain.entity.Image;
 import com.runningmate.runningmate.image.service.ImageUploadService;
 import com.runningmate.runningmate.project.domain.entity.Project;
@@ -13,7 +12,6 @@ import com.runningmate.runningmate.project.dto.ProjectPositionSaveRequestDto;
 import com.runningmate.runningmate.project.dto.ProjectSaveRequestDto;
 import com.runningmate.runningmate.project.dto.ProjectSkillSaveRequestDto;
 import com.runningmate.runningmate.project.service.ProjectService;
-import com.runningmate.runningmate.user.entity.User;
 import com.runningmate.runningmate.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,9 +50,6 @@ class ProjectServiceTest {
     private ApplyQuestionRepository mybatisApplyQuestionRepository;
 
     @Mock
-    private UserRepository userRepositoryImpl;
-
-    @Mock
     private ImageUploadService awsS3ImageUploadService;
 
     @Test
@@ -85,10 +80,9 @@ class ProjectServiceTest {
 
         MockMultipartFile multipartFile = new MockMultipartFile("file", "file", "image/jpeg", "file".getBytes());
 
-        when(userRepositoryImpl.findByEmail(any(String.class))).thenReturn(new User());
         when(awsS3ImageUploadService.upload(multipartFile)).thenReturn(new Image(1L, "file", "file", LocalDateTime.now(), LocalDateTime.now()));
 
-        projectService.createProject("email@runningmate.com", projectSaveRequestDto, multipartFile);
+        projectService.createProject(1L, projectSaveRequestDto, multipartFile);
 
         verify(awsS3ImageUploadService, times(1)).upload(any(MultipartFile.class));
         verify(mybatisProjectRepository, times(1)).save(any(Project.class));


### PR DESCRIPTION
변경된 유저 서비스 적용
- 기존: 세션에서 이메일 주소를 리턴 받아 유저 아이디 조회 후 leader에 저장
- 변경: 세션에서 long 타입의 user id를 리턴 받아 leader에 저장