### PR TITLE
jasypt password 주입 방식 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
 
     steps:
       - uses: actions/checkout@v2

--- a/src/main/java/com/runningmate/runningmate/configuration/JasyptConfig.java
+++ b/src/main/java/com/runningmate/runningmate/configuration/JasyptConfig.java
@@ -17,7 +17,7 @@ public class JasyptConfig{
     public StringEncryptor  stringEncryptor() {
         PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
         SimpleStringPBEConfig config = new SimpleStringPBEConfig();
-        String encryptKey = System.getProperty("jasypt.encryptor.password");
+        String encryptKey = System.getenv("JASYPT_PASSWORD");
 
         if (encryptKey == null) {
             throw new RuntimeException();


### PR DESCRIPTION
jasypt password 시스템 환경변수에서 가져오도록 변경
- 기존 vm option 주입 방식으로는 github action ci 사용 시 통합 테스트 환경에서 키를 노출하지 않고 테스트를 진행할 수 없는 문제가 있음.