### PR TITLE
Redis Cache 설정

### DIFF
--- a/src/main/java/com/runningmate/runningmate/RunningmateApplication.java
+++ b/src/main/java/com/runningmate/runningmate/RunningmateApplication.java
@@ -2,8 +2,10 @@ package com.runningmate.runningmate;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class RunningmateApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/runningmate/runningmate/configuration/CacheConfiguration.java
+++ b/src/main/java/com/runningmate/runningmate/configuration/CacheConfiguration.java
@@ -1,0 +1,78 @@
+package com.runningmate.runningmate.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class CacheConfiguration {
+
+    @Value("${spring.redis.cache.host}")
+    private String cacheHostName;
+
+    @Value("${spring.redis.cache.port}")
+    private int cachePort;
+
+    @Value("${spring.redis.cache.password}")
+    private String cachePassword;
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModules(new JavaTimeModule(), new Jdk8Module());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return objectMapper;
+    }
+
+    @Bean
+    public ObjectMapper cacheObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.activateDefaultTyping(
+            BasicPolymorphicTypeValidator.builder().allowIfSubType(Object.class).build(),
+            ObjectMapper.DefaultTyping.NON_FINAL);
+        objectMapper.registerModules(new JavaTimeModule(), new Jdk8Module());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        return objectMapper;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisCacheConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(cacheHostName);
+        redisStandaloneConfiguration.setPort(cachePort);
+        redisStandaloneConfiguration.setPassword(cachePassword);
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisCacheConnectionFactory, ObjectMapper cacheObjectMapper) {
+        RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .entryTtl(Duration.ofSeconds(60))
+            .serializeKeysWith(RedisSerializationContext
+                .SerializationPair
+                .fromSerializer(new StringRedisSerializer())).serializeValuesWith(RedisSerializationContext.SerializationPair
+                .fromSerializer(new GenericJackson2JsonRedisSerializer(cacheObjectMapper)));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisCacheConnectionFactory)
+            .cacheDefaults(configuration).build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,10 +21,15 @@ spring.redis.lettuce.pool.max-active=10
 spring.redis.lettuce.pool.max-idle=10
 spring.redis.lettuce.pool.min-idle=2
 spring.redis.lettuce.pool.max-wait=5000
-spring.redis.port=6380
+
 spring.redis.host=ENC(O7Dq8d/KYGeVoVXoxXSpIGKht3EaxtKBGPDZCHTXWrohdTGPOxwVIZimVf9nDu8+WRcd0FDysVP/OwEFS9sNUQ==)
+spring.redis.port=6380
 spring.redis.password=ENC(6aDV//Xba/XMasY6G53zB7Uwki8aM+Hq)
 spring.redis.timeout=10000
+
+spring.redis.cache.host=ENC(ezqCvw3ipeyL5pnxxV00GEupWyYKbG4Z)
+spring.redis.cache.port=6379
+spring.redis.cache.password=ENC(rE4CHp4In72U0xDM9EdTwzg/W9UH+mUM)
 
 jasypt.encryptor.algorithm=PBEWithMD5AndDES
 


### PR DESCRIPTION
프로젝트에서 Cache를 사용하기위한 Redis서버와 연동 및 CacheManager정의

ObjectMapper Cache용 일반용 구분 이유
- 설정을 추가하지않은 ObjectMapper를 사용해 Java Object를 직렬화하여 Redis에 저장한 후 다시 역직렬화해서 가져올 때 어떤 타입으로 가져와야할지 몰라 Entity Object로 Cast에 실패하는 예외 발생
- 변환 시 유형정보를 추가해주는 설정을 적용한 ObjectMapper를 사용해 위의 예외가 발생하지 않도록함
- 유형정보를 추가해주는 설정을 적용한 ObjectMapper만을 사용할 경우 응답으로 전달되는 본문에 객체의 유형정보가 포함되 전송되기때문에 유형정보를 포함시키지 않는 일반 ObjectMapper를 빈으로 등록해 MessageConverter에서는 일반 ObjectMapper를 사용하도록 함