### PR TITLE
프로젝트 조회 시 응답 데이터 변경

### DIFF
--- a/src/main/java/com/runningmate/runningmate/common/utils/SessionUtils.java
+++ b/src/main/java/com/runningmate/runningmate/common/utils/SessionUtils.java
@@ -52,7 +52,9 @@ public class SessionUtils{
      * @author junsoo
      */
     public static long getLoginSessionUserId() {
-        return Long.valueOf(StringUtils.getStringSafeFromObj(SessionUtils.getSession().getAttribute(LOGIN_USER_ID)));
+        String userId = (String) SessionUtils.getSession().getAttribute(LOGIN_USER_ID);
+
+        return Long.parseLong(userId == null ? "0" : userId);
     }
 
     /**

--- a/src/main/java/com/runningmate/runningmate/like/domain/repository/LikeCacheRepository.java
+++ b/src/main/java/com/runningmate/runningmate/like/domain/repository/LikeCacheRepository.java
@@ -21,6 +21,15 @@ public class LikeCacheRepository {
     private final RedisTemplate<String, Object> redisCacheTemplate;
     private final StringRedisTemplate stringCacheRedisTemplate;
 
+    public Map<Long, Boolean> existLike(long userId, long id) {
+        Boolean exist = redisCacheTemplate.opsForSet().isMember(redisCacheService.generateKey(KeyPrefix.LIKE, id), userId);
+
+        Map<Long, Boolean> result = new HashMap<>();
+        result.put(id, exist);
+
+        return result;
+    }
+
     public Map<Long, Boolean> existLike(long userId, List<Long> ids) {
         RedisSerializer keySerializer = redisCacheTemplate.getKeySerializer();
         RedisSerializer valueSerializer = redisCacheTemplate.getValueSerializer();
@@ -45,6 +54,15 @@ public class LikeCacheRepository {
         }
 
         return existMap;
+    }
+
+    public Map<Long, Integer> findLikeCount(long id) {
+        String count = stringCacheRedisTemplate.opsForValue().get(redisCacheService.generateKey(KeyPrefix.LIKE_COUNT, id));
+
+        Map<Long, Integer> countMap = new HashMap<>();
+        countMap.put(id, count == null ? 0 : Integer.parseInt(count));
+
+        return countMap;
     }
 
     public Map<Long, Integer> findLikeCount(List<Long> ids) {

--- a/src/main/java/com/runningmate/runningmate/project/controller/ProjectController.java
+++ b/src/main/java/com/runningmate/runningmate/project/controller/ProjectController.java
@@ -37,18 +37,16 @@ public class ProjectController {
 
     @GetMapping("/projects")
     public ResponseEntity<List<ProjectInfoResponseDto>> getProjects(@RequestBody ProjectSearchRequestDto projectSearchRequestDto) {
-        List<ProjectInfoResponseDto> response = projectService.getProjects(projectSearchRequestDto).stream()
-            .map(ProjectInfoResponseDto::of)
-            .collect(Collectors.toList());
+        long userId = SessionUtils.getLoginSessionUserId();
 
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(projectService.getProjects(userId, projectSearchRequestDto));
     }
 
     @GetMapping("/project/{projectId}")
     public ResponseEntity<ProjectInfoResponseDto> getProject(@PathVariable("projectId") long projectId) {
-        ProjectInfoResponseDto response = ProjectInfoResponseDto.of(projectService.getProject(projectId));
+        long userId = SessionUtils.getLoginSessionUserId();
 
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(projectService.getProject(userId, projectId));
     }
 
     @LoginCheck

--- a/src/main/java/com/runningmate/runningmate/project/domain/entity/Project.java
+++ b/src/main/java/com/runningmate/runningmate/project/domain/entity/Project.java
@@ -3,6 +3,7 @@ package com.runningmate.runningmate.project.domain.entity;
 import com.runningmate.runningmate.image.domain.entity.Image;
 import com.runningmate.runningmate.project.dto.request.ProjectUpdateRequestDto;
 import com.runningmate.runningmate.user.entity.User;
+import java.util.ArrayList;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -30,6 +31,7 @@ public class Project {
     private List<ProjectPosition> projectPositions;
     private List<ProjectSkill> projectSkills;
     private List<ApplyQuestion> applyQuestions;
+    private List<ProjectMember> projectMembers;
 
     public void updateInfo(ProjectUpdateRequestDto projectUpdateRequestDto) {
         this.beginDate = projectUpdateRequestDto.getBeginDate();

--- a/src/main/java/com/runningmate/runningmate/project/dto/response/ProjectInfoResponseDto.java
+++ b/src/main/java/com/runningmate/runningmate/project/dto/response/ProjectInfoResponseDto.java
@@ -1,9 +1,11 @@
 package com.runningmate.runningmate.project.dto.response;
 
 import com.runningmate.runningmate.project.domain.entity.Project;
+import com.runningmate.runningmate.project.domain.entity.ProjectMember;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,11 +30,15 @@ public class ProjectInfoResponseDto {
     private LocalDateTime updateDate;
     private String imagePath;
 
+    private int likeCount;
+    private boolean likePushed;
+
     private List<ProjectPositionInfoResponseDto> positions;
     private List<ProjectSkillInfoResponseDto> skills;
     private List<ApplyQuestionInfoResponseDto> applyQuestions;
+    private List<ProjectMemberInfoResponseDto> members;
 
-    public static ProjectInfoResponseDto of(Project project) {
+    public static ProjectInfoResponseDto of(Project project, Map<Long, Integer> likeCountMap) {
 
         return ProjectInfoResponseDto.builder()
             .projectId(project.getProjectId())
@@ -46,6 +52,7 @@ public class ProjectInfoResponseDto {
             .createDate(project.getCreateDate())
             .updateDate(project.getUpdateDate())
             .imagePath(project.getImage().getStorageFileName())
+            .likeCount(likeCountMap.get(project.getProjectId()))
             .positions(project.getProjectPositions().stream()
                 .map(ProjectPositionInfoResponseDto::of)
                 .collect(Collectors.toList()))
@@ -54,6 +61,40 @@ public class ProjectInfoResponseDto {
                 .collect(Collectors.toList()))
             .applyQuestions(project.getApplyQuestions().stream()
                 .map(ApplyQuestionInfoResponseDto::of)
+                .collect(Collectors.toList()))
+            .members(project.getProjectMembers().stream()
+                .map(ProjectMemberInfoResponseDto::of)
+                .collect(Collectors.toList()))
+            .build();
+    }
+
+    public static ProjectInfoResponseDto of(Project project, Map<Long, Integer> likeCountMap, Map<Long, Boolean> likeExistMap) {
+
+        return ProjectInfoResponseDto.builder()
+            .projectId(project.getProjectId())
+            .leaderEmail(project.getLeader().getEmail())
+            .leaderNickname(project.getLeader().getNickName())
+            .beginDate(project.getBeginDate())
+            .endDate(project.getEndDate())
+            .title(project.getTitle())
+            .contents(project.getContents())
+            .status(project.getStatus().toString())
+            .createDate(project.getCreateDate())
+            .updateDate(project.getUpdateDate())
+            .imagePath(project.getImage().getStorageFileName())
+            .likeCount(likeCountMap.get(project.getProjectId()))
+            .likePushed(likeExistMap.get(project.getProjectId()))
+            .positions(project.getProjectPositions().stream()
+                .map(ProjectPositionInfoResponseDto::of)
+                .collect(Collectors.toList()))
+            .skills(project.getProjectSkills().stream()
+                .map(ProjectSkillInfoResponseDto::of)
+                .collect(Collectors.toList()))
+            .applyQuestions(project.getApplyQuestions().stream()
+                .map(ApplyQuestionInfoResponseDto::of)
+                .collect(Collectors.toList()))
+            .members(project.getProjectMembers().stream()
+                .map(ProjectMemberInfoResponseDto::of)
                 .collect(Collectors.toList()))
             .build();
     }

--- a/src/main/java/com/runningmate/runningmate/project/dto/response/ProjectMemberInfoResponseDto.java
+++ b/src/main/java/com/runningmate/runningmate/project/dto/response/ProjectMemberInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.runningmate.runningmate.project.dto.response;
+
+import com.runningmate.runningmate.project.domain.entity.ProjectMember;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectMemberInfoResponseDto {
+    private long projectMemberId;
+    private long projectPositionId;
+    private long userId;
+
+    public static ProjectMemberInfoResponseDto of(ProjectMember projectMember) {
+        return ProjectMemberInfoResponseDto.builder()
+            .projectMemberId(projectMember.getProjectMemberId())
+            .projectPositionId(projectMember.getProjectPosition().getProjectPositionId())
+            .userId(projectMember.getUser().getUserId())
+            .build();
+    }
+}

--- a/src/main/resources/mapper/project/ProjectMapper.xml
+++ b/src/main/resources/mapper/project/ProjectMapper.xml
@@ -28,6 +28,7 @@
         <collection property="projectPositions" resultMap="projectPositionMap"/>
         <collection property="projectSkills" resultMap="projectSkillMap"/>
         <collection property="applyQuestions" resultMap="applyQuestionMap"/>
+        <collection property="projectMembers" resultMap="projectMemberMap"/>
     </resultMap>
 
     <resultMap id="projectPositionMap" type="com.runningmate.runningmate.project.domain.entity.ProjectPosition">
@@ -52,6 +53,18 @@
     <resultMap id="applyQuestionMap" type="com.runningmate.runningmate.project.domain.entity.ApplyQuestion">
         <id column="apply_question_id"  property="applyQuestionId"/>
         <result column="question"       property="question"/>
+    </resultMap>
+
+    <resultMap id="projectMemberMap" type="com.runningmate.runningmate.project.domain.entity.ProjectMember">
+        <id column="project_member_id"  property="projectMemberId"/>
+
+        <association property="projectPosition" javaType="com.runningmate.runningmate.project.domain.entity.ProjectPosition">
+            <id column="m_project_position_id" property="projectPositionId"/>
+        </association>
+
+        <association property="user" javaType="com.runningmate.runningmate.user.entity.User">
+            <id column="m_user_id"  property="userId"/>
+        </association>
     </resultMap>
 
     <select id="selectProjects" resultMap="projectMap">
@@ -134,6 +147,9 @@
             , s.skill_name
             , a_q.apply_question_id
             , a_q.question
+            , p_m.project_member_id
+            , p_m.project_position_id m_project_position_id
+            , p_m.user_id m_user_id
         FROM project p
             JOIN user u ON p.leader = u.user_id
             JOIN image i ON p.image_id = i.image_id
@@ -142,6 +158,7 @@
             JOIN project_skill p_s ON p.project_id = p_s.project_id
             JOIN skill s ON p_s.skill_id = s.skill_id
             JOIN apply_question a_q ON p.project_id = a_q.project_id
+            LEFT JOIN project_member p_m ON p_p.project_position_id = p_m.project_position_id
         WHERE p.project_id = #{projectId}
     </select>
 


### PR DESCRIPTION
## 작업내용
프로젝트 목록 조회 시 좋아요 개수와 좋아요 클릭 여부 포함
프로젝트 상세 조회 시 좋아요 개수와 좋아요 클릭 여부 + 프로젝트 멤버 정보 포함

SessionUtils
비로그인 상태의 클라이언트 요청에서 유저 아이디 조회 시 NullPointException 발생 -> 0을 리턴하도록 수정